### PR TITLE
feat: add deep watch on marker coordinates

### DIFF
--- a/lib/components/marker.component.ts
+++ b/lib/components/marker.component.ts
@@ -152,6 +152,7 @@ export default defineComponent({
     watch(
       () => props.coordinates,
       (v) => marker.value?.setLngLat(v),
+      { deep: true },
     );
     watch(
       () => props.draggable,


### PR DESCRIPTION
As I mentioned in #81, a shallow marker coordinates watch does not allow the coordinates of markers to be changed independently. Here is a small fix that ensures deep watch for marker coordinates