### PR TITLE
Add Deck.gl Layers and Utility Support for vue-maplibre-gL

### DIFF
--- a/lib/components/deck-layers/arc.layer.ts
+++ b/lib/components/deck-layers/arc.layer.ts
@@ -1,0 +1,31 @@
+import { defineComponent } from "vue";
+import { ArcLayer, type ArcLayerProps } from "@deck.gl/layers";
+import { useDeckLayer } from "@/lib/composable/useDeckLayer";
+import { type PickingInfo } from "@deck.gl/core";
+import {
+  arcProps,
+  arcPropsKeys,
+  genDeckLayerOpts,
+  type TooltipContent,
+} from "@/lib/lib/deck.layer.lib";
+
+/**
+ * Deck.gl Arc Layer
+ *
+ * See the [https://deck.gl/docs/api-reference/layers/arc-layer]
+ */
+export default defineComponent({
+  name: "MglDeckArcLayer",
+  props: {
+    ...arcProps(),
+  },
+  setup(props) {
+    const opts = { ...props } as ArcLayerProps & {
+      getTooltip?: ((info: PickingInfo) => TooltipContent) | null;
+    };
+    return useDeckLayer(
+      opts,
+      new ArcLayer(genDeckLayerOpts({ ...opts }, arcPropsKeys)),
+    );
+  },
+});

--- a/lib/components/deck-layers/geojson.layer.ts
+++ b/lib/components/deck-layers/geojson.layer.ts
@@ -1,0 +1,32 @@
+import { defineComponent } from "vue";
+import { GeoJsonLayer, type GeoJsonLayerProps } from "@deck.gl/layers";
+import { useDeckLayer } from "@/lib/composable/useDeckLayer";
+import { type PickingInfo } from "@deck.gl/core";
+import {
+  genDeckLayerOpts,
+  geojsonProps,
+  geoJsonPropsKeys,
+  type TooltipContent,
+} from "@/lib/lib/deck.layer.lib";
+
+/**
+ * Deck.gl Arc Layer
+ *
+ * See the [https://deck.gl/docs/api-reference/layers/geojson-layer]
+ */
+export default defineComponent({
+  name: "MglDeckGeojsonLayer",
+  props: {
+    ...geojsonProps(),
+  },
+  setup(props) {
+    const opts = { ...props } as GeoJsonLayerProps & {
+      getTooltip?: ((info: PickingInfo) => TooltipContent) | null;
+    };
+
+    return useDeckLayer(
+      opts,
+      new GeoJsonLayer(genDeckLayerOpts({ ...opts }, geoJsonPropsKeys)),
+    );
+  },
+});

--- a/lib/composable/useDeckLayer.ts
+++ b/lib/composable/useDeckLayer.ts
@@ -1,0 +1,55 @@
+import type {
+  DeckLayer,
+  DeckLayerProps,
+  TooltipContent,
+} from "@/lib/lib/deck.layer.lib.ts";
+import {
+  createCommentVNode,
+  inject,
+  onBeforeUnmount,
+  ref,
+  warn,
+  watch,
+} from "vue";
+import { isLoadedSymbol, mapSymbol } from "@/lib/types";
+import { MapboxOverlay } from "@deck.gl/mapbox";
+import type { PickingInfo } from "@deck.gl/core";
+
+export function useDeckLayer(
+  props: DeckLayerProps & {
+    getTooltip?: ((info: PickingInfo) => TooltipContent) | null;
+  },
+  layerConstructor: DeckLayer,
+) {
+  const map = inject(mapSymbol)!;
+  const isLoaded = inject(isLoadedSymbol)!;
+  const overlay = ref();
+
+  if (!map) {
+    warn(`Deck.gl layers require a Deck.gl map instance.`);
+    return;
+  }
+
+  function addLayer() {
+    overlay.value = new MapboxOverlay({
+      layers: [layerConstructor],
+      ...(props.getTooltip && {
+        getTooltip: (f) => props.getTooltip?.(f),
+      }),
+    });
+
+    map.value!.addControl(overlay.value);
+  }
+
+  watch(isLoaded, (il) => {
+    if (il) {
+      addLayer();
+    }
+  });
+
+  onBeforeUnmount(() => {
+    map.value!.removeControl(overlay.value);
+  });
+
+  return () => createCommentVNode(`${props.id} Deck Layer`);
+}

--- a/lib/lib/deck.layer.lib.ts
+++ b/lib/lib/deck.layer.lib.ts
@@ -1,0 +1,626 @@
+import type {
+  ArcLayerProps,
+  GeoJsonLayerProps,
+  BitmapLayerProps,
+  ColumnLayerProps,
+  LineLayerProps,
+  PolygonLayerProps,
+  ScatterplotLayerProps,
+  PathLayerProps,
+  IconLayerProps,
+  ArcLayer,
+  ColumnLayer,
+  GeoJsonLayer,
+  BitmapLayer,
+  LineLayer,
+  PolygonLayer,
+  ScatterplotLayer,
+  PathLayer,
+  IconLayer,
+} from "@deck.gl/layers";
+
+import { type ComponentPropsOptions, type PropType } from "vue";
+import {
+  COORDINATE_SYSTEM,
+  LayerExtension,
+  type PickingInfo,
+  type Color,
+  type Unit,
+  type Position,
+  type LayerProps,
+  type LayerData,
+  type Accessor,
+  type Material,
+} from "@deck.gl/core";
+import type { MjolnirEvent } from "mjolnir.js";
+import type { Feature, Geometry } from "geojson";
+
+export type DeckLayer =
+  | ArcLayer
+  | GeoJsonLayer
+  | BitmapLayer
+  | ColumnLayer
+  | LineLayer
+  | PolygonLayer
+  | ScatterplotLayer
+  | PathLayer
+  | IconLayer;
+
+export type DeckLayerProps =
+  | ArcLayerProps
+  | GeoJsonLayerProps
+  | BitmapLayerProps
+  | ColumnLayerProps
+  | LineLayerProps
+  | PolygonLayerProps
+  | ScatterplotLayerProps
+  | PathLayerProps
+  | IconLayerProps;
+
+export type PointType =
+  | "circle"
+  | "icon"
+  | "text"
+  | "circle+icon"
+  | "circle+text"
+  | "icon+text"
+  | "icon+circle"
+  | "text+circle"
+  | "text+icon";
+
+export type TooltipContent = string | HTMLElement | null;
+
+export const baseLayerProps: ComponentPropsOptions = {
+  // basic props
+  id: {
+    type: String as PropType<string>,
+    required: true,
+  },
+  data: {
+    type: [Object, String] as PropType<unknown>,
+  },
+  visible: {
+    type: Boolean as PropType<boolean>,
+    default: true,
+  },
+  opacity: {
+    type: Number as PropType<number>,
+    default: 1,
+  },
+  extensions: {
+    type: Array as PropType<LayerExtension[]>,
+  },
+  onError: {
+    type: Function as unknown as PropType<
+      ((error: Error) => boolean | void) | null
+    >,
+    default: undefined,
+  },
+
+  // Interaction Properties
+  pickable: {
+    type: Boolean as PropType<boolean>,
+    default: false,
+  },
+  onHover: {
+    type: Function as unknown as PropType<
+      ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null
+    >,
+    default: undefined,
+  },
+  onClick: {
+    type: Function as unknown as PropType<
+      ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null
+    >,
+    default: undefined,
+  },
+  onDragStart: {
+    type: Function as unknown as PropType<
+      ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null
+    >,
+    default: undefined,
+  },
+  onDrag: {
+    type: Function as unknown as PropType<
+      ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null
+    >,
+    default: undefined,
+  },
+  onDragEnd: {
+    type: Function as unknown as PropType<
+      ((pickingInfo: PickingInfo, event: MjolnirEvent) => boolean | void) | null
+    >,
+    default: undefined,
+  },
+  highlightColor: {
+    type: [Array, Function] as unknown as PropType<
+      Color | ((pickingInfo: PickingInfo) => void)
+    >,
+    default: () => [0, 0, 128, 128],
+  },
+  highlightedObjectIndex: {
+    type: [Number, null],
+    default: null,
+  },
+  autoHighlight: {
+    type: Boolean,
+    default: false,
+  },
+
+  // Coordinate System Properties
+  coordinateSystem: {
+    type: Number,
+    default: COORDINATE_SYSTEM.DEFAULT,
+  },
+  coordinateOrigin: {
+    type: Array as unknown as PropType<[number, number, number]>,
+    default: () => [0, 0, 0],
+  },
+  wrapLongitude: {
+    type: Boolean,
+    default: false,
+  },
+  modelMatrix: {
+    type: Array as PropType<number[]>,
+    default: undefined,
+  },
+
+  // data properties
+  dataComparator: {
+    type: Function as unknown as PropType<
+      | (<LayerDataT = LayerData<unknown>>(
+          newData: LayerDataT,
+          oldData?: LayerDataT,
+        ) => boolean)
+      | null
+    >,
+  },
+  _dataDiff: {
+    type: Function as unknown as PropType<
+      | (<LayerDataT = LayerData<unknown>>(
+          newData: LayerDataT,
+          oldData?: LayerDataT,
+        ) => { startRow: number; endRow?: number }[])
+      | null
+    >,
+  },
+  dataTransform: {
+    type: Function as unknown as PropType<
+      | (<LayerDataT = LayerData<unknown>>(
+          data: unknown,
+          previousData?: LayerDataT,
+        ) => LayerDataT)
+      | null
+    >,
+    default: undefined,
+  },
+  positionFormat: {
+    type: String as PropType<"XYZ" | "XY">,
+    default: "XYZ",
+  },
+  colorFormat: {
+    type: String as PropType<"RGBA" | "RGB">,
+    default: "RGBA",
+  },
+  numInstances: {
+    type: Number as PropType<number | null>,
+    default: undefined,
+  },
+};
+export const baseLayerKeys: (keyof LayerProps)[] = [
+  "id",
+  "data",
+  "visible",
+  "opacity",
+  "extensions",
+  "onError",
+  "pickable",
+  "onHover",
+  "onClick",
+  "onDragStart",
+  "onDrag",
+  "onDragEnd",
+  "highlightColor",
+  "highlightedObjectIndex",
+  "autoHighlight",
+  "coordinateSystem",
+  "coordinateOrigin",
+  "wrapLongitude",
+  "modelMatrix",
+  "dataComparator",
+  "_dataDiff",
+  "dataTransform",
+  "positionFormat",
+  "colorFormat",
+  "numInstances",
+];
+
+export function arcProps(): ComponentPropsOptions {
+  return {
+    ...baseLayerProps,
+    greatCircle: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    numSegments: {
+      type: Number as PropType<number>,
+      default: 50,
+    },
+    widthUnits: {
+      type: String as PropType<Unit>,
+      default: "pixels",
+    },
+    widthScale: {
+      type: Number as PropType<number>,
+      default: 1,
+    },
+    widthMinPixels: {
+      type: Number as PropType<number>,
+      default: 0,
+    },
+    widthMaxPixels: {
+      type: Number as PropType<number>,
+      default: Number.MAX_SAFE_INTEGER,
+    },
+    getSourcePosition: {
+      type: Function as unknown as PropType<Accessor<unknown, Position>>,
+      default: (object: { sourcePosition: Position }) => object.sourcePosition,
+    },
+    getTargetPosition: {
+      type: Function as unknown as PropType<Accessor<unknown, Position>>,
+      default: (object: { targetPosition: Position }) => object.targetPosition,
+    },
+    getSourceColor: {
+      type: Function as unknown as PropType<Accessor<unknown, Color>>,
+      default: () => [0, 0, 0, 255],
+    },
+    getTargetColor: {
+      type: Function as unknown as PropType<Accessor<unknown, Color>>,
+      default: () => [0, 0, 0, 255],
+    },
+    getWidth: {
+      type: Number as PropType<Accessor<unknown, number>>,
+      default: 1,
+    },
+    getHeight: {
+      type: Number as PropType<Accessor<unknown, number>>,
+      default: 1,
+    },
+    getTilt: {
+      type: Number as PropType<Accessor<unknown, number>>,
+      default: 0,
+    },
+    getTooltip: {
+      type: Function as unknown as PropType<
+        ((info: PickingInfo) => TooltipContent) | null
+      >,
+    },
+  };
+}
+export const arcPropsKeys: (keyof ArcLayerProps)[] = [
+  ...baseLayerKeys,
+  "greatCircle",
+  "numSegments",
+  "widthUnits",
+  "widthScale",
+  "widthMinPixels",
+  "widthMaxPixels",
+  "getSourcePosition",
+  "getTargetPosition",
+  "getSourceColor",
+  "getTargetColor",
+  "getWidth",
+  "getHeight",
+  "getTilt",
+];
+
+export function geojsonProps(): ComponentPropsOptions {
+  return {
+    ...baseLayerProps,
+    pointType: {
+      type: String as PropType<PointType>,
+      default: "circle",
+    },
+    // fill color props
+    filled: {
+      type: Boolean as PropType<boolean>,
+      default: true,
+    },
+    getFillColor: {
+      type: [Array, Function] as unknown as PropType<
+        Accessor<Feature<Geometry, unknown>, Color>
+      >,
+      default: () => [0, 0, 0, 255],
+    },
+    // stroke options
+    stroked: {
+      type: Boolean as PropType<boolean>,
+      default: true,
+    },
+    getLineColor: {
+      type: [Array, Function] as unknown as PropType<
+        Accessor<Feature<Geometry, unknown>, Color>
+      >,
+      default: () => [0, 0, 0, 255],
+    },
+    getLineWidth: {
+      type: [Number, Function] as PropType<
+        Accessor<Feature<Geometry, unknown>, number>
+      >,
+      default: 1,
+    },
+    lineWidthUnits: {
+      type: String as PropType<Unit>,
+      default: "meters",
+    },
+    lineWidthScale: {
+      type: Number as PropType<number>,
+      default: 1,
+    },
+    lineWidthMinPixels: {
+      type: Number as PropType<number>,
+      default: 0,
+    },
+    lineWidthMaxPixels: {
+      type: Number as PropType<number>,
+      default: Number.MAX_SAFE_INTEGER,
+    },
+    lineCapRounded: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    lineJointRounded: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    lineMiterLimit: {
+      type: Number as PropType<number>,
+      default: 4,
+    },
+    lineBillboard: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    // 3D options
+    extruded: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    wireframe: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    getElevation: {
+      type: [Number, Function] as PropType<
+        Accessor<Feature<Geometry, unknown>, number>
+      >,
+      default: 1000,
+    },
+    elevationScale: {
+      type: Number as PropType<number>,
+      default: 1,
+    },
+    material: {
+      type: [Boolean, Object] as PropType<Material>,
+      default: true,
+    },
+    _full3d: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    getPointRadius: {
+      type: [Number, Function] as PropType<
+        Accessor<Feature<Geometry, unknown>, number>
+      >,
+      default: 1,
+    },
+    pointRadiusUnits: {
+      type: String as PropType<Unit>,
+    },
+    pointRadiusScale: {
+      type: Number as PropType<number>,
+      default: 1,
+    },
+    pointRadiusMinPixels: {
+      type: Number as PropType<number>,
+      default: 0,
+    },
+    pointRadiusMaxPixels: {
+      type: Number as PropType<number>,
+      default: Number.MAX_SAFE_INTEGER,
+    },
+    pointAntialiasing: {
+      type: Boolean as PropType<boolean>,
+      default: true,
+    },
+    pointBillboard: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    getText: {
+      type: Function as PropType<Accessor<Feature<Geometry, unknown>, unknown>>,
+      default: (f: { properties: { text: unknown } }) => f.properties.text,
+    },
+    getTextColor: {
+      type: [Array, Function] as unknown as PropType<
+        Accessor<Feature<Geometry, unknown>, Color>
+      >,
+      default: () => [0, 0, 0, 255],
+    },
+    getTextAngle: {
+      type: Number as PropType<Accessor<Feature<Geometry, unknown>, number>>,
+      default: 0,
+    },
+
+    getTextSize: {
+      type: Number as PropType<Accessor<Feature<Geometry, unknown>, number>>,
+      default: 32,
+    },
+    getTextAnchor: {
+      type: String as PropType<Accessor<Feature<Geometry, unknown>, string>>,
+      default: "middle",
+    },
+    getTextAlignmentBaseline: {
+      type: String as PropType<Accessor<Feature<Geometry, unknown>, string>>,
+      default: "center",
+    },
+    getTextPixelOffset: {
+      type: [Array, Function] as PropType<
+        Accessor<Feature<Geometry, unknown>, number[]>
+      >,
+      default: () => [0, 0],
+    },
+    getTextBackgroundColor: {
+      type: [Array, Function] as unknown as PropType<
+        Accessor<Feature<Geometry, unknown>, Color>
+      >,
+      default: () => [255, 255, 255, 255],
+    },
+    getTextBorderColor: {
+      type: [Array, Function] as unknown as PropType<
+        Accessor<Feature<Geometry, unknown>, Color>
+      >,
+      default: () => [0, 0, 0, 255],
+    },
+    getTextBorderWidth: {
+      type: Number as PropType<Accessor<Feature<Geometry, unknown>, number>>,
+      default: 0,
+    },
+    textSizeUnits: {
+      type: String as PropType<Unit>,
+      default: "pixels",
+    },
+    textSizeScale: {
+      type: Number as PropType<number>,
+      default: 1,
+    },
+    textSizeMinPixels: {
+      type: Number as PropType<number>,
+      default: 0,
+    },
+    textSizeMaxPixels: {
+      type: Number as PropType<number>,
+      default: Number.MAX_SAFE_INTEGER,
+    },
+    textCharacterSet: {
+      type: [String, Array] as PropType<unknown>,
+    },
+    textFontFamily: {
+      type: String as PropType<string>,
+      default: "Monaco, monospace",
+    },
+    textFontWeight: {
+      type: [Number, String] as PropType<number | string>,
+      default: "normal",
+    },
+    textLineHeight: {
+      type: Number as PropType<number>,
+      default: 1,
+    },
+    textMaxWidth: {
+      type: Number as PropType<number>,
+      default: -1,
+    },
+    textWordBreak: {
+      type: String as PropType<string>,
+      default: "break-word",
+    },
+    textBackground: {
+      type: Boolean as PropType<boolean>,
+      default: false,
+    },
+    textBackgroundPadding: {
+      type: Array as PropType<number[]>,
+      default: () => [0, 0],
+    },
+    textOutlineColor: {
+      type: Array as unknown as PropType<Color>,
+      default: () => [0, 0, 0, 255],
+    },
+    textOutlineWidth: {
+      type: Number as PropType<number>,
+      default: 0,
+    },
+    textBillboard: {
+      type: Boolean as PropType<boolean>,
+      default: true,
+    },
+    textFontSettings: {
+      type: Object,
+    },
+    getTooltip: {
+      type: Function as unknown as PropType<
+        ((info: PickingInfo) => TooltipContent) | null
+      >,
+    },
+  };
+}
+export const geoJsonPropsKeys: (keyof GeoJsonLayerProps)[] = [
+  ...baseLayerKeys,
+  "pointType",
+  "filled",
+  "getFillColor",
+  "stroked",
+  "getLineColor",
+  "getLineWidth",
+  "lineWidthUnits",
+  "lineWidthScale",
+  "lineWidthMinPixels",
+  "lineWidthMaxPixels",
+  "lineCapRounded",
+  "lineJointRounded",
+  "lineMiterLimit",
+  "lineBillboard",
+  "extruded",
+  "wireframe",
+  "getElevation",
+  "elevationScale",
+  "material",
+  "_full3d",
+  "getPointRadius",
+  "pointRadiusUnits",
+  "pointRadiusScale",
+  "pointRadiusMinPixels",
+  "pointRadiusMaxPixels",
+  "pointAntialiasing",
+  "pointBillboard",
+  "getText",
+  "getTextColor",
+  "getTextAngle",
+  "getTextSize",
+  "getTextAnchor",
+  "getTextAlignmentBaseline",
+  "getTextPixelOffset",
+  "getTextBackgroundColor",
+  "getTextBorderColor",
+  "getTextBorderWidth",
+  "textSizeUnits",
+  "textSizeScale",
+  "textSizeMinPixels",
+  "textSizeMaxPixels",
+  "textCharacterSet",
+  "textFontFamily",
+  "textFontWeight",
+  "textLineHeight",
+  "textMaxWidth",
+  "textWordBreak",
+  "textBackground",
+  "textBackgroundPadding",
+  "textOutlineColor",
+  "textOutlineWidth",
+  "textBillboard",
+  "textFontSettings",
+];
+
+export function genDeckLayerOpts<T extends DeckLayerProps>(
+  props: T & { getTooltip?: ((info: PickingInfo) => TooltipContent) | null },
+  validProps: Array<keyof T>,
+): Partial<T> {
+  for (const opt of Object.keys(props) as Array<keyof T>) {
+    if (props[opt] === undefined || !validProps.includes(opt)) {
+      delete props[opt];
+    }
+  }
+
+  return props;
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
   },
   "devDependencies": {
     "@babel/types": "^7.23.9",
+    "@deck.gl/core": "^9.0.35",
+    "@deck.gl/layers": "^9.0.35",
+    "@deck.gl/mapbox": "^9.0.35",
     "@eslint/js": "^9.1.1",
     "@indoorequal/vue-maplibre-gl": "workspace:^",
     "@maplibre/maplibre-gl-inspect": "^1.7.0",


### PR DESCRIPTION
#### **Summary of Changes**
This pull request enhances the package with the following additions:
1. **New Components for Deck.gl Layers**:
    - Added `MglDeckGeojsonLayer` component to integrate Deck.gl's `GeoJsonLayer` ([@commit:43bab18a]()).
    - Added `MglDeckArcLayer` component to integrate Deck.gl's `ArcLayer` ([@commit:2dba67d3]()).

2. **Core Composable for Layer Management**:
    - Introduced `useDeckLayer` composable to handle lifecycle and reactivity for Deck.gl layers within Maplibre ([@commit:462eb07f]()).

3. **Utility and Prop Configuration**:
    - Added `deck.layer.lib.ts`, which defines common and layer-specific props with utilities for Deck.gl layers, ensuring reusable, type-safe layer configurations ([@commit:9503c64c]()).

4. **New Dependencies**:
    - Added Deck.gl-related packages (`@deck.gl/core`, `@deck.gl/layers`, `@deck.gl/mapbox`) to the project (`package.json` updates) ([@commit:b0b75cca]()).

#### **Features**
- **New Deck.gl Layers**: Support for `ArcLayer` and `GeoJsonLayer`, integrated as reusable Vue components.
- **Dynamic Tooltip Support**: Enables reactive tooltips for layers using `getTooltip` functionality.
- **Interactive Map Layers**: Allows developers to add, update, and remove custom Deck.gl layers easily.
- **Composable Architecture**: Simplifies usage of Deck.gl layers with Maplibre in Vue projects.

#### **Motivation**
The goal of these changes is to expand the functionality of the `@indoorequal/vue-maplibre-gl` package by introducing seamless integration with Deck.gl layers. These enhancements bring extended interactivity, 3D visualization, and customization options for applications using the library. The composable and utility-driven design ensures easier implementation and extension of Deck.gl layers within Vue projects.
#### **Future Plans**
This is just the beginning of integrating Deck.gl into the `@indoorequal/vue-maplibre-gl` package. Over time, the implementation will be extended to include **support for all available Deck.gl layers**, ensuring the package becomes a comprehensive solution for Deck.gl and Maplibre users. Future layers to be added include `ScatterplotLayer`, `IconLayer`, `BitmapLayer`, and many more.
#### **Testing**
- The changes have been tested with dynamic datasets for both `ArcLayer` and `GeoJsonLayer`.
- Verified layer interactivity, tooltip rendering, and reactivity under different map states