### PR TITLE
Export `MapInstance` from mapRegistry

### DIFF
--- a/lib/main.ts
+++ b/lib/main.ts
@@ -20,7 +20,7 @@ export * from "@/lib/components";
 
 // addition exports
 export * from "@/lib/types";
-export { useMap, MapInstance } from "@/lib/lib/mapRegistry";
+export { useMap, type MapInstance } from "@/lib/lib/mapRegistry";
 export { Position } from "@/lib/components/controls/position.enum";
 export { useControl } from "@/lib/composable/useControl";
 export { usePositionWatcher } from "@/lib/composable/usePositionWatcher";

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -20,7 +20,7 @@ export * from "@/lib/components";
 
 // addition exports
 export * from "@/lib/types";
-export { useMap } from "@/lib/lib/mapRegistry";
+export { useMap, MapInstance } from "@/lib/lib/mapRegistry";
 export { Position } from "@/lib/components/controls/position.enum";
 export { useControl } from "@/lib/composable/useControl";
 export { usePositionWatcher } from "@/lib/composable/usePositionWatcher";


### PR DESCRIPTION
As the title suggests, export the MapInstance type for use in our own code.