### PR TITLE
TS driven layer props

### DIFF
--- a/lib/components/layers/background.layer.ts
+++ b/lib/components/layers/background.layer.ts
@@ -7,7 +7,7 @@ import {
   watch,
 } from "vue";
 import { isLoadedSymbol, mapSymbol } from "@/lib/types";
-import { LAYER_EVENTS, LayerEventType } from "@/lib/lib/layer.lib";
+import { LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useDisposableLayer } from "@/lib/composable/useDisposableLayer";
 
 /**

--- a/lib/components/layers/background.layer.ts
+++ b/lib/components/layers/background.layer.ts
@@ -52,7 +52,7 @@ export default defineComponent({
      */
     paint: Object as PropType<BackgroundLayerSpecification["paint"]>,
   },
-  emits: [...LAYER_EVENTS],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props) {
     const map = inject(mapSymbol)!;
     const isLoaded = inject(isLoadedSymbol)!;

--- a/lib/components/layers/background.layer.ts
+++ b/lib/components/layers/background.layer.ts
@@ -7,7 +7,7 @@ import {
   watch,
 } from "vue";
 import { isLoadedSymbol, mapSymbol } from "@/lib/types";
-import { LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { LAYER_EVENTS, LayerEventType } from "@/lib/lib/layer.lib";
 import { useDisposableLayer } from "@/lib/composable/useDisposableLayer";
 
 /**

--- a/lib/components/layers/circle.layer.ts
+++ b/lib/components/layers/circle.layer.ts
@@ -1,6 +1,6 @@
 import type { CircleLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerEventType, LayerProps } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/circle.layer.ts
+++ b/lib/components/layers/circle.layer.ts
@@ -1,6 +1,6 @@
 import type { CircleLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerEventType, LayerProps } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglCircleLayer",
-  props: { ...layerProps<CircleLayerSpecification>() },
-  emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  props: layerProps<CircleLayerSpecification>(),
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  setup(props: LayerProps<CircleLayerSpecification>) {
     return useLayer<CircleLayerSpecification>("circle", props);
   },
 });

--- a/lib/components/layers/circle.layer.ts
+++ b/lib/components/layers/circle.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglCircleLayer",
   props: layerProps<CircleLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<CircleLayerSpecification>) {
     return useLayer<CircleLayerSpecification>("circle", props);
   },

--- a/lib/components/layers/fill.layer.ts
+++ b/lib/components/layers/fill.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglFillLayer",
   props: layerProps<FillLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<FillLayerSpecification>) {
     return useLayer<FillLayerSpecification>("fill", props);
   },

--- a/lib/components/layers/fill.layer.ts
+++ b/lib/components/layers/fill.layer.ts
@@ -1,6 +1,6 @@
 import type { FillLayerSpecification } from "maplibre-gl";
-import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { defineComponent, ComponentPropsOptions } from "vue";
+import { layerProps, LAYER_EVENTS, LayerEventType, LayerProps } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglFillLayer",
-  props: { ...layerProps<FillLayerSpecification>() },
-  emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  props: layerProps<FillLayerSpecification>(),
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  setup(props: LayerProps<FillLayerSpecification>) {
     return useLayer<FillLayerSpecification>("fill", props);
   },
 });

--- a/lib/components/layers/fill.layer.ts
+++ b/lib/components/layers/fill.layer.ts
@@ -1,5 +1,5 @@
 import type { FillLayerSpecification } from "maplibre-gl";
-import { defineComponent, ComponentPropsOptions } from "vue";
+import { defineComponent } from "vue";
 import { layerProps, LAYER_EVENTS, LayerEventType, LayerProps } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 

--- a/lib/components/layers/fill.layer.ts
+++ b/lib/components/layers/fill.layer.ts
@@ -1,6 +1,6 @@
 import type { FillLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerEventType, LayerProps } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/fillExtrusion.layer.ts
+++ b/lib/components/layers/fillExtrusion.layer.ts
@@ -1,6 +1,6 @@
 import type { FillExtrusionLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/fillExtrusion.layer.ts
+++ b/lib/components/layers/fillExtrusion.layer.ts
@@ -1,6 +1,6 @@
 import type { FillExtrusionLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglFillExtrusionLayer",
-  props: { ...layerProps<FillExtrusionLayerSpecification>() },
-  emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  props: layerProps<FillExtrusionLayerSpecification>(),
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  setup(props: LayerProps<FillExtrusionLayerSpecification>) {
     return useLayer<FillExtrusionLayerSpecification>("fill-extrusion", props);
   },
 });

--- a/lib/components/layers/fillExtrusion.layer.ts
+++ b/lib/components/layers/fillExtrusion.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglFillExtrusionLayer",
   props: layerProps<FillExtrusionLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<FillExtrusionLayerSpecification>) {
     return useLayer<FillExtrusionLayerSpecification>("fill-extrusion", props);
   },

--- a/lib/components/layers/heatmap.layer.ts
+++ b/lib/components/layers/heatmap.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglHeatmapLayer",
   props: layerProps<HeatmapLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<HeatmapLayerSpecification>) {
     return useLayer<HeatmapLayerSpecification>("heatmap", props);
   },

--- a/lib/components/layers/heatmap.layer.ts
+++ b/lib/components/layers/heatmap.layer.ts
@@ -1,6 +1,6 @@
 import type { HeatmapLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerProps } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglHeatmapLayer",
-  props: { ...layerProps<HeatmapLayerSpecification>() },
+  props: layerProps<HeatmapLayerSpecification>(),
   emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  setup(props: LayerProps<HeatmapLayerSpecification>) {
     return useLayer<HeatmapLayerSpecification>("heatmap", props);
   },
 });

--- a/lib/components/layers/heatmap.layer.ts
+++ b/lib/components/layers/heatmap.layer.ts
@@ -1,6 +1,6 @@
 import type { HeatmapLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/heatmap.layer.ts
+++ b/lib/components/layers/heatmap.layer.ts
@@ -1,6 +1,6 @@
 import type { HeatmapLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerProps } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglHeatmapLayer",
   props: layerProps<HeatmapLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<string>)],
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
   setup(props: LayerProps<HeatmapLayerSpecification>) {
     return useLayer<HeatmapLayerSpecification>("heatmap", props);
   },

--- a/lib/components/layers/hillshade.layer.ts
+++ b/lib/components/layers/hillshade.layer.ts
@@ -1,6 +1,6 @@
 import type { HillshadeLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglHillshadeLayer",
-  props: { ...layerProps<HillshadeLayerSpecification>() },
-  emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  props: layerProps<HillshadeLayerSpecification>(),
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  setup(props: LayerProps<HillshadeLayerSpecification>) {
     return useLayer<HillshadeLayerSpecification>("hillshade", props);
   },
 });

--- a/lib/components/layers/hillshade.layer.ts
+++ b/lib/components/layers/hillshade.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglHillshadeLayer",
   props: layerProps<HillshadeLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<HillshadeLayerSpecification>) {
     return useLayer<HillshadeLayerSpecification>("hillshade", props);
   },

--- a/lib/components/layers/hillshade.layer.ts
+++ b/lib/components/layers/hillshade.layer.ts
@@ -1,6 +1,6 @@
 import type { HillshadeLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/line.layer.ts
+++ b/lib/components/layers/line.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglLineLayer",
   props: layerProps<LineLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<LineLayerSpecification>) {
     return useLayer<LineLayerSpecification>("line", props);
   },

--- a/lib/components/layers/line.layer.ts
+++ b/lib/components/layers/line.layer.ts
@@ -1,6 +1,6 @@
 import type { LineLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglLineLayer",
-  props: { ...layerProps<LineLayerSpecification>() },
-  emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  props: layerProps<LineLayerSpecification>(),
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  setup(props: LayerProps<LineLayerSpecification>) {
     return useLayer<LineLayerSpecification>("line", props);
   },
 });

--- a/lib/components/layers/line.layer.ts
+++ b/lib/components/layers/line.layer.ts
@@ -1,6 +1,6 @@
 import type { LineLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/raster.layer.ts
+++ b/lib/components/layers/raster.layer.ts
@@ -1,6 +1,6 @@
 import type { RasterLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerEventType, LayerProps } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/raster.layer.ts
+++ b/lib/components/layers/raster.layer.ts
@@ -1,6 +1,6 @@
 import type { RasterLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerEventType, LayerProps } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglRasterLayer",
-  props: { ...layerProps<RasterLayerSpecification>() },
-  emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  props: layerProps<RasterLayerSpecification>(),
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  setup(props: LayerProps<RasterLayerSpecification>) {
     return useLayer<RasterLayerSpecification>("raster", props);
   },
 });

--- a/lib/components/layers/raster.layer.ts
+++ b/lib/components/layers/raster.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglRasterLayer",
   props: layerProps<RasterLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<RasterLayerSpecification>) {
     return useLayer<RasterLayerSpecification>("raster", props);
   },

--- a/lib/components/layers/symbol.layer.ts
+++ b/lib/components/layers/symbol.layer.ts
@@ -1,6 +1,6 @@
 import type { SymbolLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
+import { layerProps, type LayerProps, LAYER_EVENTS, type LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**

--- a/lib/components/layers/symbol.layer.ts
+++ b/lib/components/layers/symbol.layer.ts
@@ -1,6 +1,6 @@
 import type { SymbolLayerSpecification } from "maplibre-gl";
 import { defineComponent } from "vue";
-import { layerProps, LAYER_EVENTS } from "@/lib/lib/layer.lib";
+import { layerProps, LAYER_EVENTS, LayerProps, LayerEventType } from "@/lib/lib/layer.lib";
 import { useLayer } from "@/lib/composable/useLayer";
 
 /**
@@ -10,9 +10,9 @@ import { useLayer } from "@/lib/composable/useLayer";
  */
 export default defineComponent({
   name: "MglSymbolLayer",
-  props: { ...layerProps<SymbolLayerSpecification>() },
-  emits: [...(LAYER_EVENTS as Array<string>)],
-  setup(props) {
+  props: layerProps<SymbolLayerSpecification>(),
+  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  setup(props: LayerProps<SymbolLayerSpecification>) {
     return useLayer<SymbolLayerSpecification>("symbol", props);
   },
 });

--- a/lib/components/layers/symbol.layer.ts
+++ b/lib/components/layers/symbol.layer.ts
@@ -11,7 +11,7 @@ import { useLayer } from "@/lib/composable/useLayer";
 export default defineComponent({
   name: "MglSymbolLayer",
   props: layerProps<SymbolLayerSpecification>(),
-  emits: [...(LAYER_EVENTS as Array<LayerEventType>)],
+  emits: [...LAYER_EVENTS] as LayerEventType[],
   setup(props: LayerProps<SymbolLayerSpecification>) {
     return useLayer<SymbolLayerSpecification>("symbol", props);
   },

--- a/lib/composable/useLayer.ts
+++ b/lib/composable/useLayer.ts
@@ -22,7 +22,7 @@ import { SourceLib } from "@/lib/lib/source.lib";
 
 export function useLayer<T extends LayersWithSource>(
   name: string,
-  props: LayerProps,
+  props: LayerProps<T>,
 ) {
   const sourceId = inject(sourceIdSymbol);
 

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -33,10 +33,7 @@ export type AddedProperties = {
   before?: string;
 }
 
-export type LayerProps<T extends LayersWithSource> = Omit<
-  (AddedProperties & T),
-  "source-layer" | "id" | "type"
->;
+export type LayerProps<T extends LayersWithSource> = AddedProperties & Omit<T, "source" | "source-layer" | "id" | "type">
 
 export type LayerEventType = keyof MapLayerEventType
 
@@ -60,9 +57,14 @@ export type LayerPropTypeNaive<T extends LayersWithSource> = {
   [K in keyof LayerProps<T>]: { type: PropType<LayerProps<T>[K]>, required?: boolean | undefined }
 }
 
-export type LayerPropTypeAdded = {layerId: {type: PropType<string>}, sourceLayer: { type: PropType<string>}, before: { type: PropType<string>}, source: { type: PropType<string>}}
+export type LayerPropTypeAdded<T extends LayersWithSource> = {
+  layerId: {type: PropType<T['id']>}, 
+  sourceLayer: { type: PropType<T['source-layer']>}, 
+  before: { type: PropType<string>}, 
+  source: { type: PropType<T['source']>}
+}
 
-export type LayerPropType<T extends LayersWithSource> = LayerPropTypeNaive<T> & LayerPropTypeAdded
+export type LayerPropType<T extends LayersWithSource> = LayerPropTypeNaive<T> & LayerPropTypeAdded<T>
 
 export function layerProps<
   T extends LayersWithSource,

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -57,10 +57,10 @@ export type LayerPropTypeNaive<T extends LayersWithSource> = {
 }
 
 export type LayerPropTypeAdded<T extends LayersWithSource> = {
-  layerId: {type: PropType<T['id']>}, 
-  sourceLayer: { type: PropType<T['source-layer']>}, 
-  before: { type: PropType<string>}, 
-  source: { type: PropType<T['source']>}
+  layerId: { type: PropType<T['id']> },
+  sourceLayer: { type: PropType<T['source-layer']> },
+  before: { type: PropType<string> },
+  source: { type: PropType<T['source']> }
 }
 
 export type LayerPropType<T extends LayersWithSource> = LayerPropTypeNaive<T> & LayerPropTypeAdded<T>
@@ -88,7 +88,7 @@ export function layerProps<
     /**
      * Layer to use from a vector tile source. Required for vector tile sources; prohibited for all other source types, including GeoJSON sources.
      */
-    sourceLayer: {type: String as PropType<T['source-layer']>},
+    sourceLayer: { type: String as PropType<T['source-layer']> },
     /**
      * The minimum zoom level for the layer. At zoom levels less than the minzoom, the layer will be hidden.
      */

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -10,6 +10,7 @@ import type {
   Map,
   MapLayerEventType,
   FilterSpecification,
+  BackgroundLayerSpecification,
 } from "maplibre-gl";
 import { type PropType, type VNode, type ComponentPropsOptions } from "vue";
 
@@ -23,8 +24,10 @@ export type LayersWithSource =
   | RasterLayerSpecification
   | HillshadeLayerSpecification;
 
-export type LayerProps = Omit<
-  LayersWithSource,
+export type LayersWithoutSource = BackgroundLayerSpecification;
+
+export type LayerProps<T extends LayersWithSource> = Omit<
+  T,
   "source" | "source-layer" | "id" | "type"
 > & {
   layerId?: string;
@@ -33,7 +36,9 @@ export type LayerProps = Omit<
   before?: string;
 };
 
-export const LAYER_EVENTS: Array<keyof MapLayerEventType> = [
+export type LayerEventType = keyof MapLayerEventType
+
+export const LAYER_EVENTS: Array<LayerEventType> = [
   "click",
   "dblclick",
   "mousedown",
@@ -47,11 +52,11 @@ export const LAYER_EVENTS: Array<keyof MapLayerEventType> = [
   "touchstart",
   "touchend",
   "touchcancel",
-];
+] as const;
 
 export function layerProps<
   T extends LayersWithSource,
->(): ComponentPropsOptions {
+>(): ComponentPropsOptions<LayerProps<T>> {
   return {
     /**
      * The id of the layer
@@ -95,13 +100,13 @@ export function layerProps<
      * See https://maplibre.org/maplibre-style-spec/layers/
      */
     paint: Object as PropType<T["paint"]>,
-  };
+  } as ComponentPropsOptions<LayerProps<T>>;
 }
 
 export function genLayerOpts<T extends LayersWithSource>(
   id: string,
   type: string,
-  props: LayerProps,
+  props: LayerProps<T>,
   source: string | undefined,
 ): T {
   const opts = {

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -26,7 +26,7 @@ export type LayersWithSource =
 export type LayersWithoutSource = BackgroundLayerSpecification;
 
 export type AddedProperties = {
-  layerId?: string;
+  layerId: string;
   sourceLayer?: string;
   source?: string;
   before?: string;

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -126,7 +126,7 @@ export function genLayerOpts<T extends LayersWithSource>(
   const opts = {
     id,
     type,
-    source: source,
+    source: props.source || source,
     metadata: props.metadata,
     minzoom: props.minzoom,
     maxzoom: props.maxzoom,

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -12,7 +12,7 @@ import type {
   FilterSpecification,
   BackgroundLayerSpecification,
 } from "maplibre-gl";
-import { type PropType, type VNode, type ComponentPropsOptions } from "vue";
+import { type PropType, type VNode } from "vue";
 
 export type LayersWithSource =
   | FillLayerSpecification
@@ -26,15 +26,17 @@ export type LayersWithSource =
 
 export type LayersWithoutSource = BackgroundLayerSpecification;
 
-export type LayerProps<T extends LayersWithSource> = Omit<
-  T,
-  "source" | "source-layer" | "id" | "type"
-> & {
+export type AddedProperties = {
   layerId?: string;
   sourceLayer?: string;
   source?: string;
   before?: string;
-};
+}
+
+export type LayerProps<T extends LayersWithSource> = Omit<
+  (AddedProperties & T),
+  "source-layer" | "id" | "type"
+>;
 
 export type LayerEventType = keyof MapLayerEventType
 
@@ -54,53 +56,65 @@ export const LAYER_EVENTS: Array<LayerEventType> = [
   "touchcancel",
 ] as const;
 
+export type LayerPropTypeNaive<T extends LayersWithSource> = {
+  [K in keyof LayerProps<T>]: { type: PropType<LayerProps<T>[K]>, required?: boolean | undefined }
+}
+
+export type LayerPropTypeAdded = {layerId: {type: PropType<string>}, sourceLayer: { type: PropType<string>}, before: { type: PropType<string>}, source: { type: PropType<string>}}
+
+export type LayerPropType<T extends LayersWithSource> = LayerPropTypeNaive<T> & LayerPropTypeAdded
+
 export function layerProps<
   T extends LayersWithSource,
->(): ComponentPropsOptions<LayerProps<T>> {
+>() {
   return {
     /**
      * The id of the layer
      */
     layerId: {
-      type: String as PropType<string>,
+      type: String as PropType<T['id']>,
       required: true,
     },
-    source: String as PropType<string>,
+    source: {
+      type: String as PropType<T['source']>
+    },
     /**
      * Arbitrary properties useful to track with the layer, but do not influence rendering. Properties should be prefixed to avoid collisions, like 'maplibre:'.
      */
-    metadata: [Object, Array, String, Number] as PropType<unknown>,
+    metadata: {
+      type: [Object, Array, String, Number] as PropType<T['metadata']>
+    },
     /**
      * Layer to use from a vector tile source. Required for vector tile sources; prohibited for all other source types, including GeoJSON sources.
      */
-    sourceLayer: String as PropType<string>,
+    sourceLayer: {type: String as PropType<T['source-layer']>},
     /**
      * The minimum zoom level for the layer. At zoom levels less than the minzoom, the layer will be hidden.
      */
-    minzoom: Number as PropType<number>,
+    minzoom: { type: Number as PropType<T['minzoom']> },
     /**
      * The maximum zoom level for the layer. At zoom levels equal to or greater than the maxzoom, the layer will be hidden.
      */
-    maxzoom: Number as PropType<number>,
+    maxzoom: { type: Number as PropType<T['maxzoom']> },
     /**
      * A expression specifying conditions on source features. Only features that match the filter are displayed. Zoom expressions in filters are only evaluated at integer zoom levels. The feature-state expression is not supported in filter expressions.
      */
-    filter: Object as PropType<FilterSpecification>,
+    filter: { type: Object as PropType<T['filter']> },
     /**
      * The ID of an existing layer to insert the new layer before, resulting in the new layer appearing visually beneath the existing layer. If this argument is not specified, the layer will be appended to the end of the layers array and appear visually above all other layers.
      */
-    before: String as PropType<string>,
+    before: { type: String as PropType<string> },
     /**
      * Layout properties for the layer.
      * See https://maplibre.org/maplibre-style-spec/layers/
      */
-    layout: Object as PropType<T["layout"]>,
+    layout: { type: Object as PropType<T["layout"]> },
     /**
      * Default paint properties for this layer.
      * See https://maplibre.org/maplibre-style-spec/layers/
      */
-    paint: Object as PropType<T["paint"]>,
-  } as ComponentPropsOptions<LayerProps<T>>;
+    paint: { type: Object as PropType<T["paint"]> },
+  };
 }
 
 export function genLayerOpts<T extends LayersWithSource>(
@@ -112,7 +126,7 @@ export function genLayerOpts<T extends LayersWithSource>(
   const opts = {
     id,
     type,
-    source: props.source || source,
+    source: source,
     metadata: props.metadata,
     minzoom: props.minzoom,
     maxzoom: props.maxzoom,

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -9,7 +9,6 @@ import type {
   SymbolLayerSpecification,
   Map,
   MapLayerEventType,
-  FilterSpecification,
   BackgroundLayerSpecification,
 } from "maplibre-gl";
 import { type PropType, type VNode } from "vue";


### PR DESCRIPTION
Took a stab at resolving some of the issues for https://github.com/indoorequal/vue-maplibre-gl/issues/150

Seemed like the main problem was that by using the spread operation we were stripping a lot of the important TS information that could be used by the language server.

```ts
props: { ...layerProps<FillLayerSpecification>() }
```
ultimately resolved to `type: any` for the props:
![Screenshot 2025-05-26 at 11 57 23 AM](https://github.com/user-attachments/assets/84337fbf-0956-48a2-866c-3cb0f6eb7f06).

Since the function is returning a new object, I'm not sure what the spread is getting the code, so I've removed it here. It could also remain if we more strictly included a return type on the props to narrow it, e.g.
```ts
props: {...layerProps<FillLayerSpecification>} as ComponentPropsOptions<LayerProps<FillLayerSpecification>>
```
![Screenshot 2025-05-26 at 12 51 42 PM](https://github.com/user-attachments/assets/92ace46e-1777-427e-af2f-28fc21af85a0)

I also improved some of the typing for the events in the hope of getting better IDE support.
