### PR TITLE
added a comment with a description and link to the default MapLibre style JSON

### DIFF
--- a/lib/components/map.component.ts
+++ b/lib/components/map.component.ts
@@ -261,6 +261,11 @@ export default defineComponent({
       type: Boolean as PropType<boolean>,
       default: undefined,
     },
+    /**
+     * An optional link to a URL, or an inlined JSON literal containing a MapLibre Style specification object.
+     * 
+     * Example: https://demotiles.maplibre.org/style.json
+     */
     mapStyle: {
       type: [String, Object] as PropType<string | StyleSpecification>,
     },


### PR DESCRIPTION
I'm always hunting down this link when scaffolding out new maps and figuring out layout stuff. I thought it would be nice to have  a note about the property/what it is and an example of a simple version for IDE support to help people get a basic map up and running quicker, so they could just grab it and drop it into the `map-style` property. 

There could even be some pros for making it the default value for the prop type, although I think that may be a little heavy handed for folks to need to opt out of.