### PR TITLE
fix: Reloading style re-adds sources and layers

### DIFF
--- a/lib/composable/useSource.ts
+++ b/lib/composable/useSource.ts
@@ -13,20 +13,20 @@ export function useSource(
     isLoaded = inject(isLoadedSymbol)!;
 
   function addSource() {
-    if (isLoaded.value) {
+    if (isLoaded.value && map.value?.isStyleLoaded()) {
       map.value!.addSource(props.sourceId, SourceLib.genSourceOpts(props));
       source.value = map.value!.getSource(props.sourceId);
     }
   }
 
   watch(isLoaded, addSource, { immediate: true });
-  map.value!.on("style.load", addSource);
+  map.value!.on("styledata", addSource);
 
   return onBeforeUnmount(() => {
     if (isLoaded.value) {
       registry.unmount();
       map.value!.removeSource(props.sourceId);
     }
-    map.value!.off("style.load", addSource);
+    map.value!.off("styledata", addSource);
   });
 }


### PR DESCRIPTION
Reactively changing the `mapStyle` property (as URL) reloads the style, but removes all sources and layers added through `<mgl-xxx/>` components. 

The cause is the `style.load` event only being called initially, and not continuously as the map style is updated. These changes check if the map style has changed and is loaded properly, in which case we will reapply the sources and layers. 