### PR TITLE
fix: Avoid reloading of URL under startup

### DIFF
--- a/lib/components/sources/vector.source.ts
+++ b/lib/components/sources/vector.source.ts
@@ -59,14 +59,18 @@ export default defineComponent({
     watch(
       [isRef(props.tiles) ? props.tiles : () => props.tiles, source],
       ([v, src]) => {
-        src?.setTiles((v as string[]) || []);
+        if (src?.loaded()) {
+          src.setTiles((v as string[]) || []);
+        }
       },
       { immediate: true },
     );
     watch(
       [isRef(props.url) ? props.url : () => props.url, source],
       ([v, src]) => {
-        src?.setUrl((v as string) || "");
+        if (src?.loaded()) {
+          src.setUrl((v as string) || "");
+        }
       },
       { immediate: true },
     );


### PR DESCRIPTION
When adding an `<mgl-vector-source>` using with `url` and `source-id`, both watchers would be triggered on page load. This aborts the initial request and fires a new one. These aborted request cause an error in MapLibre-GL and cause the entire source to not be loaded.

```
Error: AJAXError: Fetch is aborted(0)
Error: AJAXError: Fetch is aborted(0)
```

```
<mgl-vector-source source-id="id" :url="url">
    <some-layer />
</mgl-vector-source> 
```

These checks make sure this doesn't happen whilst the source is not fully loaded yet.
