### PR TITLE
Global layer event handling

### DIFF
--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -199,7 +199,6 @@ export function unregisterLayerEvents(map: Map, layerId: string, vn: VNode) {
   if (!vn.props) {
     return;
   }
-  map._getMapId();
 
   for (const eventName of LAYER_EVENTS) {
     unsubscribeLayerEvent(map, layerId, eventName);

--- a/lib/lib/layer.lib.ts
+++ b/lib/lib/layer.lib.ts
@@ -10,6 +10,7 @@ import type {
   Map,
   MapLayerEventType,
   BackgroundLayerSpecification,
+  Subscription,
 } from "maplibre-gl";
 import { type PropType, type VNode } from "vue";
 
@@ -144,6 +145,37 @@ export function genLayerOpts<T extends LayersWithSource>(
   return opts;
 }
 
+/** Internal map of current map layer event handlers. */
+const layerEventSubscriptions = {} as Record<string, Subscription>;
+
+function layerEventId(map: Map, layerId: string, eventName: LayerEventType) {
+  return `${map._getMapId()}:${layerId}:${eventName}`;
+}
+
+/** Unregister any map event handlers for given layer/event combo. */
+function unsubscribeLayerEvent(
+  map: Map,
+  layerId: string,
+  eventName: LayerEventType,
+) {
+  const subscriptionId = layerEventId(map, layerId, eventName);
+  if (subscriptionId in layerEventSubscriptions) {
+    layerEventSubscriptions[subscriptionId].unsubscribe();
+    delete layerEventSubscriptions[subscriptionId];
+  }
+}
+
+/** Add layer event subscription. */
+function subscribeLayerEvent(
+  map: Map,
+  layerId: string,
+  eventName: LayerEventType,
+  subscription: Subscription,
+) {
+  unsubscribeLayerEvent(map, layerId, eventName);
+  layerEventSubscriptions[layerEventId(map, layerId, eventName)] = subscription;
+}
+
 export function registerLayerEvents(map: Map, layerId: string, vn: VNode) {
   if (!vn.props) {
     return;
@@ -151,9 +183,14 @@ export function registerLayerEvents(map: Map, layerId: string, vn: VNode) {
 
   for (const eventName of LAYER_EVENTS) {
     const evProp =
-      "on" + eventName.charAt(0).toUpperCase() + eventName.substr(1);
+      "on" + eventName.charAt(0).toUpperCase() + eventName.substring(1);
     if (vn.props[evProp]) {
-      map.on(eventName, layerId, vn.props[evProp]);
+      subscribeLayerEvent(
+        map,
+        layerId,
+        eventName,
+        map.on(eventName, layerId, vn.props[evProp]),
+      );
     }
   }
 }
@@ -162,12 +199,9 @@ export function unregisterLayerEvents(map: Map, layerId: string, vn: VNode) {
   if (!vn.props) {
     return;
   }
+  map._getMapId();
 
   for (const eventName of LAYER_EVENTS) {
-    const evProp =
-      "on" + eventName.charAt(0).toUpperCase() + eventName.substr(1);
-    if (vn.props[evProp]) {
-      map.off(eventName, layerId, vn.props[evProp]);
-    }
+    unsubscribeLayerEvent(map, layerId, eventName);
   }
 }


### PR DESCRIPTION
## Problem / Motivation

We have a map installation where the event handler for various `<mgl-*-layer>`s are reactive and changes during the life cycle. This means that the `map.off(event, vn.props[evProp])` mechanism fails, due to changed content in the props. This again, causes several event handlers to build up every time a layer is built and destructed.

## Suggested resolution

This alter the way `vue-maplibre-gl` handles subscribed map layer events. The previous model was based on using `map.off(event, handler)` for unsubscribing, assuming the handler stayed the same in the VNode's props during the entire component cycle. This isn't the case always, and ideally there should be watchers on these too.

In any case. Now, when creating map layer event listeners, these are mapped into a global `Record<string, Subscription>` map where the `Subscription` is the result of the `map.on(event, handler)` execution.

When registering events, any previously events are moved out of the way (unsubscribed) and the new event is replaced. The ID of this map is based on map instance, layer ID and event type. I think that should be sufficiently unique for the entire life cycle of `vue-maplibre-gl`.